### PR TITLE
Fix: Correct dashboard progress calculation

### DIFF
--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -148,9 +148,14 @@ export default function DashboardPage() {
         setTodayRecords(todayRecordsData)
 
         // 進捗状況を計算
-        if (todayRecordsData.length > 0) {
-          const takenCount = todayRecordsData.filter((record) => record.status === "taken").length
-          setProgress(Math.round((takenCount / todayRecordsData.length) * 100))
+        const totalScheduledDosesToday = validatedMedications.reduce(
+          (sum, med) => sum + (Array.isArray(med.frequency) ? med.frequency.length : 0),
+          0,
+        )
+        const takenDosesToday = todayRecordsData.filter((record) => record.status === "taken").length
+
+        if (totalScheduledDosesToday > 0) {
+          setProgress(Math.round((takenDosesToday / totalScheduledDosesToday) * 100))
         } else {
           setProgress(0)
         }
@@ -240,8 +245,18 @@ export default function DashboardPage() {
       setTodayRecords([newRecord, ...todayRecords])
 
       // 進捗状況を更新
-      const takenCount = todayRecords.filter((record) => record.status === "taken").length + 1
-      setProgress(Math.round((takenCount / (todayRecords.length + 1)) * 100))
+      const totalScheduledDoses = medications.reduce(
+        (sum, med) => sum + (Array.isArray(med.frequency) ? med.frequency.length : 0),
+        0,
+      )
+      const updatedTodayRecords = [newRecord, ...todayRecords]
+      const takenDoses = updatedTodayRecords.filter((record) => record.status === "taken").length
+
+      if (totalScheduledDoses > 0) {
+        setProgress(Math.round((takenDoses / totalScheduledDoses) * 100))
+      } else {
+        setProgress(0)
+      }
 
       toast({
         title: "服薬を記録しました",


### PR DESCRIPTION
The medication progress percentage on the dashboard was previously calculated based on the number of medication records created for the day, rather than the total number of doses scheduled for the day.

This commit corrects the logic to:
1. Calculate the total number of scheduled doses for the current day by summing the frequencies of all registered medications.
2. Calculate the number of doses actually taken today from the medication records.
3. Update the progress percentage based on (taken doses / scheduled doses).

This ensures the dashboard accurately reflects your adherence to your medication schedule for the day.