### PR TITLE
Fix(script): Correct Promise types for FCM responses in server_remind…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,175 @@
+# 服薬管理アプリケーション
 
+## 1. プロジェクト概要
+
+これは、ユーザーがお薬の服用状況、スケジュール、服薬遵守を記録・管理するのを支援するための服薬管理アプリケーションです。主な機能には、服薬記録、スケジュール管理、リマインダー（プッシュ通知経由）、および扶養家族の服薬管理のためのペアレンタルコントロール機能が含まれます。
+
+このアプリケーションは、Next.jsフロントエンドと、オプションでスケジュールされたプッシュ通知リマインダーを送信するためのサーバーサイドスクリプトで構成されています。
+
+## 2. Next.js アプリケーション (フロントエンド)
+
+### 前提条件
+- Node.js (最新LTS版を推奨)
+- pnpm (または npm/yarn)
+
+### 環境変数
+Next.jsアプリケーションのルートディレクトリに `.env.local` ファイルを作成してください。このファイルにはFirebaseクライアントサイド設定を保存します。
+
+**必要なFirebase環境変数:**
+```env
+NEXT_PUBLIC_FIREBASE_API_KEY="YOUR_API_KEY"
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="YOUR_AUTH_DOMAIN"
+NEXT_PUBLIC_FIREBASE_PROJECT_ID="YOUR_PROJECT_ID"
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="YOUR_STORAGE_BUCKET"
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID="YOUR_MESSAGING_SENDER_ID"
+NEXT_PUBLIC_FIREBASE_APP_ID="YOUR_APP_ID"
+
+# このVAPIDキーはWebプッシュ通知 (Firebase Cloud Messaging) に不可欠です
+# Firebaseプロジェクト設定で生成してください: プロジェクト設定 > Cloud Messaging > ウェブ設定 > ウェブプッシュ証明書
+NEXT_PUBLIC_FIREBASE_VAPID_KEY="YOUR_VAPID_KEY"
+```
+`"YOUR_..."` の部分を実際のFirebaseプロジェクトの認証情報に置き換えてください。
+
+### 開発
+1.  **依存関係のインストール:**
+    ```bash
+    pnpm install
+    # または: npm install
+    ```
+2.  **開発サーバーの実行:**
+    ```bash
+    pnpm dev
+    # または: npm run dev
+    ```
+    通常、アプリケーションは `http://localhost:3000` で利用可能になります。
+
+### 本番ビルドと実行
+1.  **アプリケーションのビルド:**
+    ```bash
+    pnpm build
+    # または: npm run build
+    ```
+2.  **本番サーバーの起動:**
+    ```bash
+    pnpm start
+    # または: npm run start
+    ```
+
+### PM2を使った運用 (本番サーバー向けオプション)
+サーバー上でNext.jsの本番プロセスを管理するために、PM2は推奨されるプロセス管理ツールです。
+```bash
+# 例: pnpm の start スクリプトを使ってアプリを起動
+pm2 start pnpm --name "medication-app" -- run start
+
+# または、より複雑な設定のために ecosystem.config.js ファイルを作成します:
+# module.exports = {
+#   apps : [{
+#     name   : "medication-app",
+#     script : "pnpm",
+#     args   : "start",
+#     env_production: {
+#       NODE_ENV: "production"
+#     }
+#   }]
+# }
+# pm2 start ecosystem.config.js --env production
+```
+
+## 3. サーバーサイド・リマインダースクリプト (`server_reminder_script_example.ts`)
+
+### 目的
+このスクリプトは、スケジュールされた服薬リマインダーのプッシュ通知を送信します。FirestoreおよびFCMとの連携に `firebase-admin` を使用します。**このスクリプトは、ユーザーが管理するサーバー（VPS、専用サーバー、Raspberry Piなど）で実行されるように設計されており、Next.jsアプリケーションのホスティング（Vercelなど）とは別個のものです。** Vercelのサーバーレス関数には実行時間制限があり、継続的に実行されるcronのようなジョブには適していない場合があるため、このスクリプトは独自のサーバーを管理するユーザー向けの代替手段を提供します。
+
+### 前提条件 (サーバー側)
+- Node.js (最新LTS版を推奨)
+- npm または pnpm
+- プロジェクト用のFirebaseサービスアカウントキー (JSONファイル)
+
+### セットアップ手順
+
+1.  **スクリプトとサービスアカウントキーの配置:**
+    -   `server_reminder_script_example.ts` (リポジトリルートから) をサーバー上のディレクトリ (例: `/opt/medication-reminder/`) にコピーします。
+    -   Firebaseプロジェクト設定 (`プロジェクト設定 > サービスアカウント > 新しい秘密鍵を生成`) からFirebaseサービスアカウントキーのJSONファイルをダウンロードします。
+    -   このキーファイル (例: `your-service-account-key.json`) を同じディレクトリに配置します。
+    -   **重要: このサービスアカウントキーファイルを安全に保管してください。適切なファイル権限を設定し (例: `chmod 600 your-service-account-key.json`)、公開アクセスできないようにしてください。**
+
+2.  **依存関係のインストール:**
+    -   スクリプトを配置したディレクトリ (例: `/opt/medication-reminder/`) に移動します:
+        ```bash
+        cd /opt/medication-reminder/
+        ```
+    -   `package.json` を初期化し、必要な依存関係をインストールします:
+        ```bash
+        npm init -y
+        npm install firebase-admin typescript ts-node
+        # または、先にJavaScriptにコンパイルしてnodeで実行する場合:
+        # npm install firebase-admin typescript
+        ```
+
+3.  **サービスアカウントキーパスの設定:**
+    -   スクリプトはデフォルトで `GOOGLE_APPLICATION_CREDENTIALS` 環境変数を使用します。
+    -   この環境変数をサービスアカウントキーJSONファイルのフルパスに設定します。この行をシェルのプロファイル (例: `~/.bashrc`, `~/.zshrc`) に追加するか、cronジョブの実行行で直接設定します。
+        ```bash
+        export GOOGLE_APPLICATION_CREDENTIALS="/opt/medication-reminder/your-service-account-key.json"
+        ```
+        (変更を新しいセッションで有効にするには、`source ~/.bashrc` を実行するか、ログアウト/ログインすることを忘れないでください。)
+    -   または (セキュリティ上推奨されず、本番環境では非推奨)、`server_reminder_script_example.ts` 内の `SERVICE_ACCOUNT_KEY_PATH` 変数を直接変更することもできます。
+
+4.  **手動テスト実行:**
+    -   cronジョブを設定する前に、スクリプトを手動でテストします:
+    -   **ts-node を使用 (開発/テストに推奨):**
+        ```bash
+        # 現在のセッションで GOOGLE_APPLICATION_CREDENTIALS が設定されていることを確認
+        npx ts-node server_reminder_script_example.ts
+        ```
+    -   **JavaScriptにコンパイルしてから実行 (本番環境、またはts-nodeを好まない場合):**
+        ```bash
+        # (任意) tsconfig.json がない場合は作成: npx tsc --init
+        # TypeScriptファイルをJavaScriptにコンパイル
+        npx tsc server_reminder_script_example.ts
+        # コンパイルされたJavaScriptファイルを実行
+        node server_reminder_script_example.js
+        ```
+    -   コンソール出力で "Firebase Admin SDK initialized successfully."、"Match found for user..."、または "No matching reminders..." といったメッセージやエラーが表示されないか確認します。
+
+### 定期実行 (Cronジョブ)
+スクリプトを一定間隔 (例: 5分ごと) で自動実行するには、cronジョブを使用します。
+
+1.  crontabを編集用に開きます:
+    ```bash
+    crontab -e
+    ```
+2.  スクリプトをスケジュールする行を追加します。パスやスケジュールは必要に応じて調整してください。
+    -   **`ts-node` を使用する例 (5分ごとに実行):**
+        ```cron
+        */5 * * * * export GOOGLE_APPLICATION_CREDENTIALS="/opt/medication-reminder/your-service-account-key.json"; /usr/local/bin/npx ts-node /opt/medication-reminder/server_reminder_script_example.ts >> /var/log/medication-reminder/cron.log 2>&1
+        ```
+    -   **コンパイル済みのJavaScriptファイルを使用する例 (5分ごとに実行):**
+        ```cron
+        */5 * * * * export GOOGLE_APPLICATION_CREDENTIALS="/opt/medication-reminder/your-service-account-key.json"; /usr/bin/node /opt/medication-reminder/server_reminder_script_example.js >> /var/log/medication-reminder/cron.log 2>&1
+        ```
+
+    **Cron設定の重要な注意点:**
+    -   **フルパス:** cronジョブでは、実行可能ファイル (`npx`, `ts-node`, `node`) およびスクリプトファイル自体へのフルパスを常に使用してください。cron環境はしばしば最小限の `PATH` しか持たないためです。フルパスは `which npx`、`which ts-node`、`which node` を使って見つけることができます。
+    -   **環境変数:** cronジョブの実行行内で `GOOGLE_APPLICATION_CREDENTIALS` が正しく設定されていること (例に示した通り)、またはcronユーザーの環境に事前に設定されていることを確認してください。
+    -   **ロギング:** 標準出力 (`>>`) と標準エラー (`2>&1`) をログファイル (例: `/var/log/medication-reminder/cron.log`) にリダイレクトして、トラブルシューティングに役立ててください。ログディレクトリが存在し、cronユーザーが書き込み可能であることを確認してください。
+    -   **サーバータイムゾーン:** サンプルスクリプト `server_reminder_script_example.ts` は、リマインダー時間との比較のために現在時刻を決定するのに `new Date()` を使用するため、それが実行されるサーバーがJST (日本標準時) に設定されていることを前提としています。サーバーが異なるタイムゾーンにある場合は、スクリプトの日時処理ロジックを調整するか、サーバーのシステムタイムゾーンがJSTであることを確認する必要があります。
+
+### 機能概要
+-   スクリプトはFirestoreの `userSettings` (`notificationsEnabled` がtrueのもの) をクエリします。
+-   ユーザーごとに、`reminderTimes` を現在のサーバー時刻 (JSTと想定) と比較します。
+-   リマインダー時刻が一致する場合、`userTokens` からユーザーのFCMトークンを取得し、FCM経由でプッシュ通知を送信します。
+-   デフォルトの通知は、タイトルが「服薬リマインダー」、本文が「お薬を飲む時間です」となります。
+
+## 4. トラブルシューティングと注意点
+
+-   **プッシュ通知の問題:**
+    -   Next.jsアプリのブラウザコンソールで、サービスワーカーの登録やFCMトークン取得に関連するエラーを確認してください。
+    -   `.env.local` で `NEXT_PUBLIC_FIREBASE_VAPID_KEY` が正しく設定されていることを確認してください。
+    -   `public` ディレクトリ内の `firebase-messaging-sw.js` が正しく設定され、アクセス可能であることを確認してください。
+    -   Firebaseコンソール (Cloud Messagingセクション) を使用して、特定のFCMトークンにテストメッセージを送信し、問題を切り分けてください。
+    -   `server_reminder_script_example.ts` からのログを確認してください (cronを使用している場合は、指定されたログファイルを確認)。
+-   **サーバーサイドスクリプト:** このスクリプトはNext.jsアプリケーションのデプロイとは別のエンティティであることを忘れないでください。独自のサーバー環境、依存関係、およびプロセス管理 (cron) が必要です。
+-   **セキュリティ:** Firebaseサービスアカウントキーは常に保護してください。リポジトリにコミットしないでください。環境変数または安全なファイルストレージメカニズムを使用してください。
+
+このREADMEは基本的なガイドを提供します。特定のデプロイ環境やニーズによっては、さらなる設定が必要になる場合があります。

--- a/server_reminder_script_example.ts
+++ b/server_reminder_script_example.ts
@@ -1,0 +1,196 @@
+import * as admin from "firebase-admin";
+// import { Timestamp } from "firebase-admin/firestore"; // If needed for more complex timestamp operations
+
+// --- Configuration ---
+// Path to your Firebase service account key JSON file
+// IMPORTANT: Secure this file and ensure the path is correct for your server environment.
+// You can set this via an environment variable for better security.
+const SERVICE_ACCOUNT_KEY_PATH = process.env.GOOGLE_APPLICATION_CREDENTIALS || "./path/to/your/serviceAccountKey.json";
+
+// Notification details
+const NOTIFICATION_TITLE = "服薬リマインダー";
+const NOTIFICATION_BODY = "お薬を飲む時間です";
+
+// --- Firebase Admin SDK Initialization ---
+try {
+  admin.initializeApp({
+    credential: admin.credential.cert(SERVICE_ACCOUNT_KEY_PATH),
+    // databaseURL: "https://<YOUR_PROJECT_ID>.firebaseio.com" // Optional: if using Realtime Database
+  });
+  console.log("Firebase Admin SDK initialized successfully.");
+} catch (error: any) {
+  console.error("Error initializing Firebase Admin SDK:", error.message);
+  process.exit(1); // Exit if Firebase Admin cannot be initialized
+}
+
+const db = admin.firestore();
+const messaging = admin.messaging();
+
+interface ReminderTimes {
+  [sessionKey: string]: string; // e.g., { "朝": "08:00", "昼": "12:30" }
+}
+
+interface UserSetting {
+  notificationsEnabled?: boolean;
+  reminderTimes?: ReminderTimes;
+  // other settings...
+}
+
+interface UserToken {
+  token?: string;
+  updatedAt?: admin.firestore.Timestamp; // To track token freshness
+  // other fields...
+}
+
+/**
+ * Main function to check for scheduled reminders and send notifications.
+ * This function is intended to be called by a cron job or similar scheduler.
+ */
+async function checkAndSendReminders() {
+  // Server is JST, so new Date() will be in JST
+  const now = new Date();
+  const currentHour = now.getHours();
+  const currentMinute = now.getMinutes();
+  const currentTimeString = `${String(currentHour).padStart(2, "0")}:${String(currentMinute).padStart(2, "0")}`;
+
+  console.log(
+    `[JST] checkAndSendReminders: Running at ${now.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}. Matching against time: ${currentTimeString}`,
+  );
+
+  try {
+    const settingsSnapshot = await db
+      .collection("userSettings")
+      .where("notificationsEnabled", "==", true)
+      .get();
+
+    if (settingsSnapshot.empty) {
+      console.log("No user settings found with notificationsEnabled:true.");
+      return;
+    }
+
+    const notificationPromises: Promise<string>[] = [];
+
+    settingsSnapshot.forEach((userSettingDoc: admin.firestore.QueryDocumentSnapshot) => {
+      const settings = userSettingDoc.data() as UserSetting;
+      const userId = userSettingDoc.id;
+
+      if (settings.reminderTimes && typeof settings.reminderTimes === 'object') {
+        for (const sessionKey in settings.reminderTimes) {
+          if (Object.prototype.hasOwnProperty.call(settings.reminderTimes, sessionKey)) {
+            const reminderTimeValue = settings.reminderTimes[sessionKey];
+            if (typeof reminderTimeValue === "string" && reminderTimeValue === currentTimeString) {
+              console.log(
+                `Match found for user ${userId}, session ${sessionKey} at time ${reminderTimeValue}`,
+              );
+              notificationPromises.push(
+                sendFcmNotification(userId, NOTIFICATION_TITLE, NOTIFICATION_BODY, sessionKey),
+              );
+            }
+          }
+        }
+      } else {
+        // console.warn(`User ${userId} has invalid or missing reminderTimes:`, settings.reminderTimes);
+      }
+    });
+
+    if (notificationPromises.length > 0) {
+      const results = await Promise.all(notificationPromises);
+      console.log("Notification sending attempts processed. Results:", results);
+    } else {
+      console.log("No matching reminders to send in this run.");
+    }
+  } catch (error: any) {
+    console.error("Error in checkAndSendReminders:", error.message, error.stack);
+  }
+}
+
+/**
+ * Sends an FCM notification to a specific user.
+ */
+async function sendFcmNotification(
+  userId: string,
+  title: string,
+  body: string,
+  sessionKey: string,
+): Promise<string> {
+  try {
+    const tokenDoc = await db.collection("userTokens").doc(userId).get();
+    if (!tokenDoc.exists) {
+      return `No token document found for user ${userId} (session: ${sessionKey}).`;
+    }
+
+    const tokenData = tokenDoc.data() as UserToken;
+    if (!tokenData || !tokenData.token) {
+      return `Token field missing or invalid for user ${userId} (session: ${sessionKey}).`;
+    }
+    const userFcmToken = tokenData.token;
+
+    const messagePayload: admin.messaging.Message = {
+      notification: { title, body },
+      token: userFcmToken,
+      webpush: {
+        notification: {
+          icon: "/icon-192x192.png", // Ensure this icon is publicly accessible from your app's domain
+                                     // Or use a full URL to a hosted image.
+          tag: `medication-reminder-${sessionKey}-${userId}`, // Optional: helps stack or replace notifications
+        },
+        fcmOptions: { link: "/" }, // URL to open on notification click
+      },
+      // data: { // Optional data payload for the client
+      //   click_action: "/",
+      //   session: sessionKey,
+      // }}
+    };
+
+    console.log(
+      `Attempting to send notification to user ${userId} for session ${sessionKey} (token: ${userFcmToken.substring(0,20)}...)`,
+    );
+    const response = await messaging.send(messagePayload);
+    console.log(`Successfully sent message to user ${userId} for session ${sessionKey}: ${response}`);
+    return response;
+  } catch (error: any) {
+    console.error(`Failed to send notification to user ${userId} for session ${sessionKey}}:`, error.code, error.message);
+    if (
+      error.code === "messaging/registration-token-not-registered" ||
+      error.code === "messaging/invalid-registration-token"
+    ) {
+      console.log(`Token for user ${userId} is invalid. Deleting from Firestore.`);
+      try {
+        await db.collection("userTokens").doc(userId).delete();
+        return `Invalid token for ${userId} deleted.`;
+      } catch (deleteError: any) {
+        console.error(`Failed to delete invalid token for user ${userId}}:`, deleteError.message);
+        return `Failed to delete invalid token for ${userId}.`;
+      }
+    }
+    return `Error sending to ${userId}: ${error.message}`;
+  }
+}
+
+// --- Script Execution ---
+// This makes the script runnable directly via `node your-script-name.js`
+// For a cron job, you would typically configure the cron to call node with this script file.
+if (require.main === module) {
+  console.log("Starting manual run of checkAndSendReminders...");
+  checkAndSendReminders()
+    .then(() => {
+      console.log("Manual run completed.");
+      // For a script that runs once and exits, you might not need to explicitly exit
+      // if there are no other pending async operations.
+      // process.exit(0); // Uncomment if you need to force exit for cron.
+    })
+    .catch((error) => {
+      console.error("Manual run failed:", error);
+      process.exit(1);
+    });
+}
+
+// For regular cron execution, you'd just ensure checkAndSendReminders() is called.
+// The `if (require.main === module)` block is for direct execution testing.
+// A cron job would simply execute `node /path/to/this/script.js` or `ts-node /path/to/this/script.ts`
+// and the main logic would be whatever is callable, e.g., checkAndSendReminders().
+
+// Example of how to make checkAndSendReminders callable for a cron:
+// (No changes needed if cron just runs the file like `node script.js`)
+
+// module.exports = { checkAndSendReminders }; // If you were to require it elsewhere.


### PR DESCRIPTION
…er_script

Updated type annotations in `server_reminder_script_example.ts`:
- Changed the type of `notificationPromises` array to `Promise<string>[]`.
- Changed the return type of `sendFcmNotification` function to `Promise<string>`.

These changes align the types with the actual return value (message ID string) of `admin.messaging().send()` for single device messages, resolving TS2694 errors related to `MessagingDevicesResponse`. Also re-verified the `firebase-admin` import syntax.