### PR TITLE
Feat: Implement dropdown navigation for settings page on mobile

### DIFF
--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -15,6 +15,8 @@ import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, For
 import { Input } from "@/components/ui/input"
 import { toast } from "@/hooks/use-toast"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectItem } from "@/components/ui/select"
+import { useIsMobile } from "@/components/ui/use-mobile"
 import { Switch } from "@/components/ui/switch"
 import { generateLinkCode } from "@/lib/utils"
 import { Copy, Unlink } from "lucide-react"
@@ -57,6 +59,14 @@ export default function SettingsPage() {
   const [inputLinkCode, setInputLinkCode] = useState("")
   const [accountToUnlink, setAccountToUnlink] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState("reminders")
+  const isMobile = useIsMobile()
+
+  const tabDefinitions = [
+    { value: "reminders", label: "リマインダー設定" },
+    { value: "notifications", label: "通知設定" },
+    { value: "account", label: "アカウント設定" },
+    { value: "parental", label: "ペアレンタルコントロール" },
+  ]
 
   const reminderForm = useForm<z.infer<typeof reminderFormSchema>>({
     resolver: zodResolver(reminderFormSchema),
@@ -559,16 +569,38 @@ export default function SettingsPage() {
       <div className="space-y-6">
         <h1 className="text-3xl font-bold tracking-tight">設定</h1>
 
-        <Tabs defaultValue="reminders" value={activeTab} onValueChange={handleTabChange}>
-          <TabsList className="mb-4 flex-wrap">
-            <TabsTrigger value="reminders">リマインダー設定</TabsTrigger>
-            <TabsTrigger value="notifications">通知設定</TabsTrigger>
-            <TabsTrigger value="account">アカウント設定</TabsTrigger>
-            <TabsTrigger value="parental">ペアレンタルコントロール</TabsTrigger>
-          </TabsList>
+        {isMobile ? (
+          <div className="mb-4">
+            <Select onValueChange={handleTabChange} value={activeTab}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="設定セクションを選択" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {tabDefinitions.map((tab) => (
+                    <SelectItem key={tab.value} value={tab.value}>
+                      {tab.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        ) : (
+          <Tabs value={activeTab} onValueChange={handleTabChange}>
+            <TabsList className="mb-4 flex-wrap">
+              {tabDefinitions.map((tab) => (
+                <TabsTrigger key={tab.value} value={tab.value}>
+                  {tab.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        )}
 
-          {activeTab === "reminders" && (
-              <Card>
+        {/* Content sections based on activeTab */}
+        {activeTab === "reminders" && (
+            <Card>
                 <CardHeader>
                   <CardTitle>リマインダー時間設定</CardTitle>
                   <CardDescription>各服用タイミングのリマインダー時間を設定します</CardDescription>
@@ -799,7 +831,8 @@ export default function SettingsPage() {
                 </CardContent>
               </Card>
           )}
-        </Tabs>
+        {/* The closing </Tabs> tag is removed here if isMobile is true, so we ensure content is always rendered */}
+        {/* For non-mobile, Tabs component is closed above */}
       </div>
   )
 }


### PR DESCRIPTION
Replaces the tab navigation with a dropdown select menu on smaller screens (less than 768px) in the settings page (`app/(main)/settings/page.tsx`) to improve responsiveness and your experience on mobile devices.

Key changes:
- Uses the `Select` component from `components/ui/select.tsx` for dropdown navigation on mobile.
- Employs the `useIsMobile` hook (`components/ui/use-mobile.tsx`) to conditionally render either the dropdown (mobile) or the existing `Tabs` component (desktop).
- Both navigation methods are driven by a common `tabDefinitions` array and update the `activeTab` state to display the relevant content section.
- The existing tab-based navigation is preserved for larger screens.

This addresses your feedback requesting a dropdown for tabs to better handle responsiveness on mobile devices.