### PR TITLE
feat: 服用タイミングに「頓服」を追加

### DIFF
--- a/app/(main)/medications/add/page.tsx
+++ b/app/(main)/medications/add/page.tsx
@@ -22,6 +22,7 @@ const frequencyItems = [
   { id: "昼", label: "昼" },
   { id: "晩", label: "晩" },
   { id: "就寝前", label: "就寝前" },
+  { id: "頓服", label: "頓服" }, // 頓服を追加
 ]
 
 const medicationFormSchema = z.object({

--- a/app/(main)/medications/edit/[id]/page.tsx
+++ b/app/(main)/medications/edit/[id]/page.tsx
@@ -22,6 +22,7 @@ const frequencyItems = [
   { id: "昼", label: "昼" },
   { id: "晩", label: "晩" },
   { id: "就寝前", label: "就寝前" },
+  { id: "頓服", label: "頓服" }, // 頓服を追加
 ]
 
 const medicationFormSchema = z.object({

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -35,6 +35,7 @@ const reminderFormSchema = z.object({
   昼: z.string().regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, "時間は HH:MM 形式で入力してください"),
   晩: z.string().regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, "時間は HH:MM 形式で入力してください"),
   就寝前: z.string().regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, "時間は HH:MM 形式で入力してください"),
+  頓服: z.string().regex(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/, "時間は HH:MM 形式で入力してください").optional().or(z.literal("")), // 頓服を追加 (オプショナル、空文字許容)
 })
 
 const accountFormSchema = z.object({
@@ -63,6 +64,7 @@ export default function SettingsPage() {
       昼: "12:00",
       晩: "18:00",
       就寝前: "22:00",
+      頓服: "", // 頓服のデフォルト値
     },
   })
 
@@ -94,6 +96,7 @@ export default function SettingsPage() {
             昼: settings.reminderTimes?.昼 || "12:00",
             晩: settings.reminderTimes?.晩 || "18:00",
             就寝前: settings.reminderTimes?.就寝前 || "22:00",
+            頓服: settings.reminderTimes?.頓服 || "", // 頓服を追加
           })
 
           // 連携コードとリンクされたアカウントを設定
@@ -157,6 +160,7 @@ export default function SettingsPage() {
               昼: "12:00",
               晩: "18:00",
               就寝前: "22:00",
+              頓服: "", // 頓服を追加
             },
             linkCode: newLinkCode,
             linkedAccounts: [],
@@ -195,8 +199,12 @@ export default function SettingsPage() {
         setIsSubmitting(false)
         return
       }
+      const reminderData = {
+        ...values,
+        頓服: values.頓服 || undefined, // 空文字の場合は undefined として保存
+      }
       await updateDoc(doc(db, "userSettings", user.uid), {
-        reminderTimes: values,
+        reminderTimes: reminderData,
         updatedAt: new Date(),
       })
 
@@ -613,6 +621,20 @@ export default function SettingsPage() {
                                   <FormControl>
                                     <Input type="time" {...field} />
                                   </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={reminderForm.control}
+                            name="頓服"
+                            render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>頓服の服用時間 (任意)</FormLabel>
+                                  <FormControl>
+                                    <Input type="time" {...field} />
+                                  </FormControl>
+                                  <FormDescription>必要な場合のみ設定してください。</FormDescription>
                                   <FormMessage />
                                 </FormItem>
                             )}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,7 @@ export interface UserSettings {
     昼: string
     晩: string
     就寝前: string
+    頓服?: string // 頓服を追加し、時刻設定はオプショナルにする
   }
   linkCode: string
   linkedAccounts: string[]
@@ -18,7 +19,7 @@ export interface Medication {
   userId: string
   name: string
   dosage: string
-  frequency: string[]
+  frequency: string[] // 例: ["朝", "昼", "晩", "就寝前", "頓服"]
   startDate: Date
   endDate?: Date | null
   notes?: string
@@ -33,7 +34,7 @@ export interface MedicationLog {
   userId: string
   medicationId: string
   takenAt: Date
-  scheduled: string // 朝, 昼, 晩, 就寝前
+  scheduled: string // 朝, 昼, 晩, 就寝前, 頓服
   skipped: boolean
   notes?: string
   createdAt: Date


### PR DESCRIPTION
- 型定義、薬剤登録・編集画面、設定画面を修正し、「頓服」を新しい服薬タイミングとして追加しました。
- 「頓服」のリマインダー時刻は任意で設定可能です。